### PR TITLE
fixed case when __PRETTY_FINCTION__ not defined

### DIFF
--- a/src/avlog.h
+++ b/src/avlog.h
@@ -5,19 +5,26 @@
 
 #include "ffmpeg.h"
 
+#ifdef __PRETTY_FUNCTION__
+#define LOGGED_NAME __PRETTY_FUNCTION__
+#else
+// should exist on C++11 compiler
+#define LOGGED_NAME __func__
+#endif
+
 /// Use null context as logging context
-#define null_log(level, format, ...)     av_log(nullptr, level, "%s: " format,  __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#define null_log(level, format, ...)     av_log(nullptr, level, "%s: " format,  LOGGED_NAME, ##__VA_ARGS__)
 
 /// Use context ptr as logging context
-#define ptr_log(level, format, ...)      av_log(m_raw, level, "%s: " format,  __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#define ptr_log(level, format, ...)      av_log(m_raw, level, "%s: " format,  LOGGED_NAME, ##__VA_ARGS__)
 
 /// Use context referenct as logging context
-#define ref_log(level, format, ...)      av_log(&m_raw, level, "%s: " format,  __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#define ref_log(level, format, ...)      av_log(&m_raw, level, "%s: " format,  LOGGED_NAME, ##__VA_ARGS__)
 
 /// Use specific context as logging context for pretty logging
-#define ctx_log(ctx, level, format, ...) av_log(ctx, level, "%s: " format,  __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#define ctx_log(ctx, level, format, ...) av_log(ctx, level, "%s: " format,  LOGGED_NAME, ##__VA_ARGS__)
 
 /// Default in-class logger
-#define fflog(level, format, ...) _log(level, "%s: " format, __PRETTY_FUNCTION__, ##__VA_ARGS__)
+#define fflog(level, format, ...) _log(level, "%s: " format, LOGGED_NAME, ##__VA_ARGS__)
 
 #endif // LOG_H


### PR DESCRIPTION
On msvc this macro is absent, so perhaps can be replaced with ```__func__``` [ref. C++11 §8.4.1[dcl.fct.def.general]/8] or something better if exists.