### PR TITLE
Fix checkCodec() call

### DIFF
--- a/src/codeccontext.h
+++ b/src/codeccontext.h
@@ -310,7 +310,7 @@ public:
     explicit CodecContextBase(const Codec &codec)
         : CodecContext2(codec, _direction, _type)
     {
-        if (checkCodec(codec, throws()))
+        if (checkCodec(codec, _direction, _type, throws()))
             m_raw = avcodec_alloc_context3(codec.raw());
     }
 


### PR DESCRIPTION
I have no idea why this compiles in GCC 5 and 6 in the first place (maybe this constructor is not used anywhere), but GCC 7 fails with this error:
```
In file included from /home/rkfg/soft/avcpp/src/codeccontext.cpp:7:0:
/home/rkfg/soft/avcpp/src/codeccontext.h: In constructor ‘av::CodecContextBase<Clazz, _direction, _type>::CodecContextBase(const av::Codec&)’:
/home/rkfg/soft/avcpp/src/codeccontext.h:313:39: error: no matching function for call to ‘av::CodecContextBase<Clazz, _direction, _type>::checkCodec(const av::Codec&, av::OptionalErrorCode)’
         if (checkCodec(codec, throws()))
                                       ^
/home/rkfg/soft/avcpp/src/codeccontext.h:132:10: note: candidate: bool av::CodecContext2::checkCodec(const av::Codec&, av::Direction, AVMediaType, av::OptionalErrorCode)
     bool checkCodec(const Codec& codec, Direction direction, AVMediaType type, OptionalErrorCode ec);
          ^~~~~~~~~~
/home/rkfg/soft/avcpp/src/codeccontext.h:132:10: note:   candidate expects 4 arguments, 2 provided
```