### PR TITLE
Allow encoder flushing

### DIFF
--- a/src/codeccontext.cpp
+++ b/src/codeccontext.cpp
@@ -68,11 +68,9 @@ int encode(AVCodecContext *avctx,
         *got_packet_ptr = 0;
 
     int ret;
-    if (frame) {
-        ret = avcodec_send_frame(avctx, frame);
-        if (ret < 0 && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)
-            return ret;
-    }
+    ret = avcodec_send_frame(avctx, frame);
+    if (ret < 0 && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)
+        return ret;
 
     ret = avcodec_receive_packet(avctx, avpkt);
     if (ret < 0 && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)


### PR DESCRIPTION
Took me a while to get why encoder can't be properly flushed. This seems to be a copypaste victim from the "decode" method but we should not prevent sending NULL frames as this is a magic value to flush the encoder.