### PR TITLE
Use 64-bit integers for bitrates

### DIFF
--- a/src/codeccontext.cpp
+++ b/src/codeccontext.cpp
@@ -560,12 +560,12 @@ void CodecContext2::setStrict(int strict) noexcept
     RAW_SET2(isValid(), strict_std_compliance, strict);
 }
 
-int32_t CodecContext2::bitRate() const noexcept
+int64_t CodecContext2::bitRate() const noexcept
 {
-    return RAW_GET2(isValid(), bit_rate, int32_t(0));
+    return RAW_GET2(isValid(), bit_rate, int64_t(0));
 }
 
-std::pair<int, int> CodecContext2::bitRateRange() const noexcept
+std::pair<int64_t, int64_t> CodecContext2::bitRateRange() const noexcept
 {
     if (isValid())
         return std::make_pair(m_raw->rc_min_rate, m_raw->rc_max_rate);
@@ -573,12 +573,12 @@ std::pair<int, int> CodecContext2::bitRateRange() const noexcept
         return std::make_pair(0, 0);
 }
 
-void CodecContext2::setBitRate(int32_t bitRate) noexcept
+void CodecContext2::setBitRate(int64_t bitRate) noexcept
 {
     RAW_SET2(isValid(), bit_rate, bitRate);
 }
 
-void CodecContext2::setBitRateRange(const std::pair<int, int> &bitRateRange) noexcept
+void CodecContext2::setBitRateRange(const std::pair<int64_t, int64_t> &bitRateRange) noexcept
 {
     if (isValid())
     {

--- a/src/codeccontext.h
+++ b/src/codeccontext.h
@@ -99,10 +99,10 @@ public:
     int strict() const noexcept;
     void setStrict(int strict) noexcept;
 
-    int32_t bitRate() const noexcept;
-    std::pair<int, int> bitRateRange() const noexcept;
-    void setBitRate(int32_t bitRate) noexcept;
-    void setBitRateRange(const std::pair<int, int> &bitRateRange) noexcept;
+    int64_t bitRate() const noexcept;
+    std::pair<int64_t, int64_t> bitRateRange() const noexcept;
+    void setBitRate(int64_t bitRate) noexcept;
+    void setBitRateRange(const std::pair<int64_t, int64_t> &bitRateRange) noexcept;
 
     // Flags
     /// Access to CODEC_FLAG_* flags


### PR DESCRIPTION
libavcodec uses 64-bit integers for bitrate (see libavcodec/avcodec.h), we should do so, too. Would help with extreme bitrates like 3+ Gbit/sec or else it will overflow.