### PR TITLE
Allow to get/set average frame rate

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -41,6 +41,11 @@ Rational Stream::sampleAspectRatio() const
     return RAW_GET2(isValid(), sample_aspect_ratio, AVRational{});
 }
 
+Rational Stream::averageFrameRate() const
+{
+    return RAW_GET2(isValid(), avg_frame_rate, AVRational{});
+}
+
 Timestamp Stream::startTime() const
 {
     return {RAW_GET2(isValid(), start_time, AV_NOPTS_VALUE), timeBase()};
@@ -105,6 +110,11 @@ void Stream::setFrameRate(const Rational &frameRate)
 void Stream::setSampleAspectRatio(const Rational &aspectRatio)
 {
     RAW_SET2(isValid(), sample_aspect_ratio, aspectRatio.getValue());
+}
+
+void Stream::setAverageFrameRate(const Rational &frameRate)
+{
+    RAW_SET2(isValid(), avg_frame_rate, frameRate.getValue());
 }
 
 int Stream::eventFlags() const noexcept

--- a/src/stream.h
+++ b/src/stream.h
@@ -35,6 +35,7 @@ public:
     Rational    frameRate()          const;
     Rational    timeBase()           const;
     Rational    sampleAspectRatio()  const;
+    Rational    averageFrameRate()   const;
     Timestamp   startTime()          const;
     Timestamp   duration()           const;
     Timestamp   currentDts()         const;
@@ -51,6 +52,7 @@ public:
     void setTimeBase(const Rational &timeBase);
     void setFrameRate(const Rational &frameRate);
     void setSampleAspectRatio(const Rational &aspectRatio);
+    void setAverageFrameRate(const Rational &frameRate);
 
     /**
      * Flags to the user to detect events happening on the stream.


### PR DESCRIPTION
This is important for containers with predefined timebase like Matroska with fixed 1 ms timebase. Without setting the average FPS manually you'll get 1000 fps (or 1k) as a result. It's usually not the true FPS but rather a best guess by the tools like ffprobe. Still, it looks ugly and can confuse less intelligent tools like TV software. Note that `setFrameRate()` doesn't help in this case hence introducing a new method.