### PR TITLE
Fix #24

### DIFF
--- a/src/formatcontext.cpp
+++ b/src/formatcontext.cpp
@@ -205,11 +205,6 @@ Stream FormatContext::addStream(const Codec &codec, OptionalErrorCode ec)
         return Stream();
     }
 
-    if (!outputFormat().codecSupported(codec)) {
-        throws_if(ec, Errors::FormatCodecUnsupported);
-        return Stream();
-    }
-
     auto rawcodec = codec.raw();
     AVStream *st = nullptr;
 


### PR DESCRIPTION
It seems something inside libav is not behaving properly. Either MKV is not well-defined in terms of supported formats or `av_codec_get_tag2` should not be used [like that](https://github.com/h4tr3d/avcpp/blob/a2be4c78fe91535498e956b089ef12cc4b5e60e5/src/format.cpp#L14). Maybe it doesn't support getting tags for subtitle streams, I have no idea really. The fact is, it prevents adding aubtitles to an MKV container and it's wrong so I removed that check. It's redundant anyway because right after adding a stream we check the result for NULL, so if it didn't work for whatever reason we'd `throw_if`.