### PR TITLE
Only throw_if in setOption if setting an option failed, fix filtergraph parsing, add sample aspect ratio accessors

### DIFF
--- a/src/codeccontext.cpp
+++ b/src/codeccontext.cpp
@@ -517,7 +517,9 @@ void CodecContext2::setOption(const string &key, const string &val, int flags, O
     if (isValid())
     {
         auto sts = av_opt_set(m_raw->priv_data, key.c_str(), val.c_str(), flags);
-        throws_if(ec, sts, ffmpeg_category());
+        if (sts) {
+            throws_if(ec, sts, ffmpeg_category());
+        }
     }
     else
     {

--- a/src/codeccontext.h
+++ b/src/codeccontext.h
@@ -396,6 +396,11 @@ public:
         return RAW_GET2(isValid(), max_b_frames, 0);
     }
 
+    Rational sampleAspectRatio() const
+    {
+        return RAW_GET(sample_aspect_ratio, AVRational());
+    }
+
     void setWidth(int w) // Note, it also sets coded_width
     {
         if (isValid() & !isOpened())
@@ -450,6 +455,11 @@ public:
     void setMaxBFrames(int maxBFrames)
     {
         RAW_SET2(isValid(), max_b_frames, maxBFrames);
+    }
+
+    void setSampleAspectRatio(const Rational& sampleAspectRatio)
+    {
+        RAW_SET(sample_aspect_ratio, sampleAspectRatio);
     }
 
 protected:

--- a/src/filters/filtergraph.cpp
+++ b/src/filters/filtergraph.cpp
@@ -165,25 +165,16 @@ void FilterGraph::parse(const string &graphDescription,
         return;
     }
 
-    struct FilterInOutDeleter
-    {
-        void operator()(AVFilterInOut *&ptr)
-        {
-            avfilter_inout_free(&ptr);
-        }
-    };
-    using FilterInOutPtr = std::unique_ptr<AVFilterInOut, FilterInOutDeleter>;
-
-    FilterInOutPtr inputs;
-    FilterInOutPtr outputs;
+    AVFilterInOut* inputs;
+    AVFilterInOut* outputs;
 
     if (graphDescription.empty()) {
         fflog(AV_LOG_ERROR, "Empty graph description");
         throws_if(ec, Errors::FilterGraphDescriptionEmpty);
         return;
     } else {
-        outputs.reset(avfilter_inout_alloc());
-        inputs.reset(avfilter_inout_alloc());
+        outputs = avfilter_inout_alloc();
+        inputs = avfilter_inout_alloc();
 
         if (!outputs || !inputs) {
             throws_if(ec, errc::not_enough_memory);
@@ -200,7 +191,7 @@ void FilterGraph::parse(const string &graphDescription,
         inputs->pad_idx     = 0;
         inputs->next        = 0;
 
-        int sts = avfilter_graph_parse(m_raw, graphDescription.c_str(), inputs.get(), outputs.get(), nullptr);
+        int sts = avfilter_graph_parse(m_raw, graphDescription.c_str(), inputs, outputs, nullptr);
         if (sts < 0) {
             throws_if(ec, sts, ffmpeg_category());
             return;

--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -176,6 +176,16 @@ void VideoFrame::setPictureType(AVPictureType type)
     RAW_SET(pict_type, type);
 }
 
+Rational VideoFrame::sampleAspectRatio() const
+{
+    return RAW_GET(sample_aspect_ratio, AVRational());
+}
+
+void VideoFrame::setSampleAspectRatio(const Rational& sampleAspectRatio)
+{
+    RAW_SET(sample_aspect_ratio, sampleAspectRatio);
+}
+
 
 AudioSamples::AudioSamples(SampleFormat sampleFormat, int samplesCount, uint64_t channelLayout, int sampleRate, int align)
 {

--- a/src/frame.h
+++ b/src/frame.h
@@ -292,6 +292,9 @@ public:
 
     AVPictureType          pictureType() const;
     void                   setPictureType(AVPictureType type = AV_PICTURE_TYPE_NONE);
+
+    Rational               sampleAspectRatio() const;
+    void                   setSampleAspectRatio(const Rational& sampleAspectRatio);
 };
 
 // Be a little back compat


### PR DESCRIPTION
We shouldn't throw if av_opt_set returned zero (success). Also fixed segfault in filtergraph parsing. We only need to manually free AVFilterInOut structures after using `avfilter_graph_parse_ptr` as in the [example](https://www.ffmpeg.org/doxygen/trunk/filtering_video_8c-example.html#a59) but we use [`avfilter_graph_parse` which frees automatically](https://www.ffmpeg.org/doxygen/trunk/graphparser_8c_source.html#l00533) (and if we do the same after the program segfaults). Hence all the unique_ptr machinery is not needed. Although the filter classes certainly needs some work to make them easier to use and more abstract, like, the in/out filters could be created automatically and we'd only provide the actual filters.

Another feature for the filters is easy access to sample (pixel) aspect ratio in video frame and codec context. It's used in filter input initialization, and while unnecessary would be good to have it exposed for consistency.