### PR TITLE
MSVC compatibility

### DIFF
--- a/src/codeccontext.cpp
+++ b/src/codeccontext.cpp
@@ -11,14 +11,14 @@ using namespace std;
 namespace av {
 namespace {
 
-std::pair<ssize_t, const error_category*>
+std::pair<int, const error_category*>
 make_error_pair(Errors errc)
 {
-    return make_pair(static_cast<ssize_t>(errc), &avcpp_category());
+    return make_pair(static_cast<int>(errc), &avcpp_category());
 }
 
-std::pair<ssize_t, const error_category*>
-make_error_pair(ssize_t status)
+std::pair<int, const error_category*>
+make_error_pair(int status)
 {
     if (status < 0)
         return make_pair(status, &ffmpeg_category());
@@ -725,7 +725,7 @@ void CodecContext2::open(const Codec &codec, AVDictionary **options, OptionalErr
         throws_if(ec, stat, ffmpeg_category());
 }
 
-std::pair<ssize_t, const error_category *> CodecContext2::decodeCommon(AVFrame *outFrame, const Packet &inPacket, size_t offset, int &frameFinished, int (*decodeProc)(AVCodecContext *, AVFrame *, int *, const AVPacket *)) noexcept
+std::pair<int, const error_category *> CodecContext2::decodeCommon(AVFrame *outFrame, const Packet &inPacket, size_t offset, int &frameFinished, int (*decodeProc)(AVCodecContext *, AVFrame *, int *, const AVPacket *)) noexcept
 {
     if (!isValid())
         return make_error_pair(Errors::CodecInvalid);
@@ -749,7 +749,7 @@ std::pair<ssize_t, const error_category *> CodecContext2::decodeCommon(AVFrame *
     return make_error_pair(decoded);
 }
 
-std::pair<ssize_t, const error_category *> CodecContext2::encodeCommon(Packet &outPacket, const AVFrame *inFrame, int &gotPacket, int (*encodeProc)(AVCodecContext *, AVPacket *, const AVFrame *, int *)) noexcept
+std::pair<int, const error_category *> CodecContext2::encodeCommon(Packet &outPacket, const AVFrame *inFrame, int &gotPacket, int (*encodeProc)(AVCodecContext *, AVPacket *, const AVFrame *, int *)) noexcept
 {
     if (!isValid()) {
         fflog(AV_LOG_ERROR, "Invalid context\n");

--- a/src/codeccontext.h
+++ b/src/codeccontext.h
@@ -132,17 +132,17 @@ protected:
     void open(const Codec &codec, AVDictionary **options, OptionalErrorCode ec);
 
 
-    std::pair<ssize_t, const std::error_category*>
+    std::pair<int, const std::error_category*>
     decodeCommon(AVFrame *outFrame, const Packet &inPacket, size_t offset, int &frameFinished,
                  int (*decodeProc)(AVCodecContext*, AVFrame*,int *, const AVPacket *)) noexcept;
 
-    std::pair<ssize_t, const std::error_category*>
+    std::pair<int, const std::error_category*>
     encodeCommon(Packet &outPacket, const AVFrame *inFrame, int &gotPacket,
                          int (*encodeProc)(AVCodecContext*, AVPacket*,const AVFrame*, int*)) noexcept;
 
 public:
     template<typename T>
-    std::pair<ssize_t, const std::error_category*>
+    std::pair<int, const std::error_category*>
     decodeCommon(T &outFrame,
                  const Packet &inPacket,
                  size_t offset,
@@ -191,7 +191,7 @@ public:
     }
 
     template<typename T>
-    std::pair<ssize_t, const std::error_category*>
+    std::pair<int, const std::error_category*>
     encodeCommon(Packet &outPacket,
                  const T &inFrame,
                  int &gotPacket,

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -63,7 +63,7 @@ public:
      */
     struct RawStringDeleter
     {
-        void operator()(char *&ptr)
+        void operator()(char *ptr)
         {
             av_freep(&ptr);
         }

--- a/src/formatcontext.cpp
+++ b/src/formatcontext.cpp
@@ -931,7 +931,7 @@ void FormatContext::closeCodecContexts()
 #endif
 }
 
-ssize_t FormatContext::checkPbError(ssize_t stat)
+int FormatContext::checkPbError(int stat)
 {
     // WORKAROUND: a lot of format specific writer_packet() functions always return zero code
     // and av_write_frame() in FFMPEG prio 1.0 does not contain follow wrapper

--- a/src/formatcontext.cpp
+++ b/src/formatcontext.cpp
@@ -240,7 +240,7 @@ bool FormatContext::seekable() const noexcept
 
 void FormatContext::seek(const Timestamp &timestamp, OptionalErrorCode ec)
 {
-    seek(timestamp.timestamp(AV_TIME_BASE_Q), -1, 0, ec);
+    seek(timestamp.timestamp(AV_TIME_BASE_Q_CPP), -1, 0, ec);
 }
 
 void FormatContext::seek(const Timestamp& timestamp, size_t streamIndex, OptionalErrorCode ec)
@@ -252,7 +252,7 @@ void FormatContext::seek(const Timestamp& timestamp, size_t streamIndex, Optiona
 
 void FormatContext::seek(const Timestamp& timestamp, bool anyFrame, OptionalErrorCode ec)
 {
-    seek(timestamp.timestamp(AV_TIME_BASE_Q), -1, anyFrame ? AVSEEK_FLAG_ANY : 0, ec);
+    seek(timestamp.timestamp(AV_TIME_BASE_Q_CPP), -1, anyFrame ? AVSEEK_FLAG_ANY : 0, ec);
 }
 
 void FormatContext::seek(const Timestamp &timestamp, size_t streamIndex, bool anyFrame, OptionalErrorCode ec)
@@ -278,7 +278,7 @@ Timestamp FormatContext::startTime() const noexcept
         return {};
     }
 
-    return {m_raw->start_time, AV_TIME_BASE_Q};
+    return {m_raw->start_time, AV_TIME_BASE_Q_CPP};
 }
 
 int FormatContext::eventFlags() const noexcept
@@ -320,7 +320,7 @@ Timestamp FormatContext::duration() const noexcept
         duration += (m_raw->duration <= INT64_MAX - 5000 ? 5000 : 0);
     }
 
-    return {duration, AV_TIME_BASE_Q};
+    return {duration, AV_TIME_BASE_Q_CPP};
 };
 
 void FormatContext::openInput(const string &uri, OptionalErrorCode ec)

--- a/src/formatcontext.h
+++ b/src/formatcontext.h
@@ -27,13 +27,13 @@ using AvioInterruptCb = std::function<int()>;
 struct CustomIO
 {
     virtual ~CustomIO() {}
-    virtual ssize_t     write(const uint8_t *data, size_t size) 
+    virtual int     write(const uint8_t *data, size_t size) 
     {
         static_cast<void>(data);
         static_cast<void>(size);
         return -1; 
     }
-    virtual ssize_t     read(uint8_t *data, size_t size)
+    virtual int     read(uint8_t *data, size_t size)
     {
         static_cast<void>(data);
         static_cast<void>(size);
@@ -202,7 +202,7 @@ private:
     void        resetSocketAccess();
     void        findStreamInfo(AVDictionary **options, size_t optionsCount, OptionalErrorCode ec);
     void        closeCodecContexts();
-    ssize_t     checkPbError(ssize_t stat);
+    int         checkPbError(int stat);
 
     void        openCustomIO(CustomIO *io, size_t internalBufferSize, bool isWritable, OptionalErrorCode ec);
     void        openCustomIOInput(CustomIO *io, size_t internalBufferSize, OptionalErrorCode ec);

--- a/src/frame.h
+++ b/src/frame.h
@@ -134,7 +134,7 @@ public:
         return {RAW_GET(pts, AV_NOPTS_VALUE), m_timeBase};
     }
 
-    void setPts(int64_t pts, Rational ptsTimeBase) attribute_deprecated
+    attribute_deprecated void setPts(int64_t pts, Rational ptsTimeBase)
     {
         RAW_SET(pts, ptsTimeBase.rescale(pts, m_timeBase));
     }

--- a/src/packet.h
+++ b/src/packet.h
@@ -53,8 +53,8 @@ public:
      * @param tsTimeBase  is a time base of setted timestamp, can be omited or sets to Rational(0,0)
      *                    that means that time base equal to packet time base.
      */
-    void setPts(int64_t pts,     const Rational &tsTimeBase = Rational(0, 0)) attribute_deprecated;
-    void setDts(int64_t dts,     const Rational &tsTimeBase = Rational(0, 0)) attribute_deprecated;
+    attribute_deprecated void setPts(int64_t pts,     const Rational &tsTimeBase = Rational(0, 0));
+    attribute_deprecated void setDts(int64_t dts,     const Rational &tsTimeBase = Rational(0, 0));
 
     void setPts(const Timestamp &pts);
     void setDts(const Timestamp &dts);

--- a/src/rational.h
+++ b/src/rational.h
@@ -10,6 +10,8 @@
 namespace av
 {
 
+#define AV_TIME_BASE_Q_CPP          AVRational{1, AV_TIME_BASE}
+
 enum
 {
     RationalMaxPrecision = 5

--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <limits>
 
 #include "timestamp.h"

--- a/src/timestamp.h
+++ b/src/timestamp.h
@@ -67,7 +67,7 @@ public:
 
 private:
     int64_t  m_timestamp = AV_NOPTS_VALUE;
-    Rational m_timebase = AV_TIME_BASE_Q;
+    Rational m_timebase = AV_TIME_BASE_Q_CPP;
 };
 
 


### PR DESCRIPTION
The changes in this PR change some parts of the code to be compatible with MSVC. I haven't tested it on gcc for cross compatibility, but it should be fine.

I'm not happy about the AV_TIMEBASE_Q_CPP macro, but I couldn't think of a properly elegant solution.