### PR TITLE
Fix a missing header needed for std min, max

### DIFF
--- a/src/timestamp.cpp
+++ b/src/timestamp.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <limits>
 
 #include "timestamp.h"


### PR DESCRIPTION
std::min/max requires the algorithm header on MSVC. Cherry picked single commit from https://github.com/h4tr3d/avcpp/pull/39. Let me know if anything else needs to be added.