### PR TITLE
Move attribute_deprecated to before function prototype

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -134,7 +134,7 @@ public:
         return {RAW_GET(pts, AV_NOPTS_VALUE), m_timeBase};
     }
 
-    void setPts(int64_t pts, Rational ptsTimeBase) attribute_deprecated
+    attribute_deprecated void setPts(int64_t pts, Rational ptsTimeBase)
     {
         RAW_SET(pts, ptsTimeBase.rescale(pts, m_timeBase));
     }

--- a/src/packet.h
+++ b/src/packet.h
@@ -53,8 +53,8 @@ public:
      * @param tsTimeBase  is a time base of setted timestamp, can be omited or sets to Rational(0,0)
      *                    that means that time base equal to packet time base.
      */
-    void setPts(int64_t pts,     const Rational &tsTimeBase = Rational(0, 0)) attribute_deprecated;
-    void setDts(int64_t dts,     const Rational &tsTimeBase = Rational(0, 0)) attribute_deprecated;
+    attribute_deprecated void setPts(int64_t pts,     const Rational &tsTimeBase = Rational(0, 0));
+    attribute_deprecated void setDts(int64_t dts,     const Rational &tsTimeBase = Rational(0, 0));
 
     void setPts(const Timestamp &pts);
     void setDts(const Timestamp &dts);


### PR DESCRIPTION
MSVC does not compile if **attribute_deprecated** is specified after the function prototype. This PR fixes that.

Cherry picked commit from https://github.com/h4tr3d/avcpp/pull/39