### PR TITLE
add AvUniquePtrDeleter for unique_ptr

### DIFF
--- a/src/avutils.cpp
+++ b/src/avutils.cpp
@@ -199,55 +199,51 @@ string error2string(int error)
     return string(errorBuf);
 }
 
-bool AvDeleter::operator()(SwsContext *&swsContext)
+bool AvUniquePtrDeleter::operator()(SwsContext *swsContext)
 {
     sws_freeContext(swsContext);
-    swsContext = nullptr;
     return true;
 }
 
-bool AvDeleter::operator()(AVCodecContext *&codecContext)
+bool AvUniquePtrDeleter::operator()(AVCodecContext *codecContext)
 {
     avcodec_close(codecContext);
     av_free(codecContext);
-    codecContext = nullptr;
     return true;
 }
 
-bool AvDeleter::operator()(AVOutputFormat *&format)
+bool AvUniquePtrDeleter::operator()(AVOutputFormat *format)
 {
     // Only set format to zero, it can'be freed by user
     format = 0;
     return true;
 }
 
-bool AvDeleter::operator()(AVFormatContext *&formatContext)
+bool AvUniquePtrDeleter::operator()(AVFormatContext *formatContext)
 {
     avformat_free_context(formatContext);
-    formatContext = nullptr;
     return true;
 }
 
-bool AvDeleter::operator()(AVFrame *&frame)
+bool AvUniquePtrDeleter::operator()(AVFrame *frame)
 {
     av_frame_free(&frame);
     return true;
 }
 
-bool AvDeleter::operator()(AVPacket *&packet)
+bool AvUniquePtrDeleter::operator()(AVPacket *packet)
 {
     av_packet_free(&packet);
     return true;
 }
 
-bool AvDeleter::operator()(AVDictionary *&dictionary)
+bool AvUniquePtrDeleter::operator()(AVDictionary *dictionary)
 {
     av_dict_free(&dictionary);
-    dictionary = nullptr;
     return true;
 }
 
-bool AvDeleter::operator ()(AVFilterInOut *&filterInOut)
+bool AvUniquePtrDeleter::operator ()(AVFilterInOut *filterInOut)
 {
     avfilter_inout_free(&filterInOut);
     return true;

--- a/tests/AvDeleter.cpp
+++ b/tests/AvDeleter.cpp
@@ -12,8 +12,15 @@
 
 using namespace std;
 
-namespace {
-
+TEST_CASE("Deleter Checking", "[AvUniquePtrDeleter]")
+{
+#if 0
+    // use AvDeleter with unique_ptr can lead to build error:
+    using deleter_t = av::AvDeleter;
+#else
+    using deleter_t = av::AvUniquePtrDeleter;
+#endif
+    std::unique_ptr<AVPacket, deleter_t> pkt(av_packet_alloc(), deleter_t{});
 }
 
 TEST_CASE("Deleter Checking", "[AvDeleter]")


### PR DESCRIPTION
Since gcc-9, use AvDeleter with unique_ptr lead to build error:
"unique_ptr's deleter must be invocable with a pointer".

Add AvUniquePtrDeleter and keep AvDeleter for backward compatibility.