### PR TITLE
Release data  pointer after successful packet creatin in Packet::setData

### DIFF
--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -166,6 +166,8 @@ bool Packet::setData(const uint8_t *newData, size_t size, OptionalErrorCode ec)
         return false;
     }
 
+    data.release();
+
     m_completeFlag = true;
 
     return true;


### PR DESCRIPTION
Otherwise data will be disposed immediately after setData and it cause  double free in Packet destructor.