### PR TITLE
Adjust to ffmpeg avformat 59 API changes.

### DIFF
--- a/src/format.h
+++ b/src/format.h
@@ -52,12 +52,11 @@ protected:
     using FFWrapperPtr<T>::m_raw;
 };
 
-
-class InputFormat : public Format<AVInputFormat>
+class InputFormat : public Format<const AVInputFormat>
 {
 public:
-    using Format<AVInputFormat>::Format;
-    using Format<AVInputFormat>::setFormat;
+    using Format<const AVInputFormat>::Format;
+    using Format<const AVInputFormat>::setFormat;
 
     InputFormat() = default;
 
@@ -68,11 +67,11 @@ public:
 };
 
 
-class OutputFormat : public Format<AVOutputFormat>
+class OutputFormat : public Format<const AVOutputFormat>
 {
 public:
-    using Format<AVOutputFormat>::Format;
-    using Format<AVOutputFormat>::setFormat;
+    using Format<const AVOutputFormat>::Format;
+    using Format<const AVOutputFormat>::setFormat;
 
     OutputFormat() = default;
 


### PR DESCRIPTION
Format functions are returning those as const pointers now.
There is ff_const59 that could have been (ab)used for transition period,
however it may disappear without warning in future.

This change should be backward compatible. 

As requested in #73 separated from meson changes.
Rebase on master; tests passing for meson build (this change + changes from #73)