### PR TITLE
Revert "Adjust to ffmpeg avformat 59 API changes."

### DIFF
--- a/src/format.h
+++ b/src/format.h
@@ -52,11 +52,12 @@ protected:
     using FFWrapperPtr<T>::m_raw;
 };
 
-class InputFormat : public Format<const AVInputFormat>
+
+class InputFormat : public Format<AVInputFormat>
 {
 public:
-    using Format<const AVInputFormat>::Format;
-    using Format<const AVInputFormat>::setFormat;
+    using Format<AVInputFormat>::Format;
+    using Format<AVInputFormat>::setFormat;
 
     InputFormat() = default;
 
@@ -67,11 +68,11 @@ public:
 };
 
 
-class OutputFormat : public Format<const AVOutputFormat>
+class OutputFormat : public Format<AVOutputFormat>
 {
 public:
-    using Format<const AVOutputFormat>::Format;
-    using Format<const AVOutputFormat>::setFormat;
+    using Format<AVOutputFormat>::Format;
+    using Format<AVOutputFormat>::setFormat;
 
     OutputFormat() = default;
 


### PR DESCRIPTION
Reverts h4tr3d/avcpp#75

PR https://github.com/h4tr3d/avcpp/pull/75 broke compilation of avcpp:
```
../../../avcpp/src/codec.cpp:131:40: error: invalid conversion from const AVOutputFormat* to AVOutputFormat* [-fpermissive]
``` 