### PR TITLE
Meson subproject sample test control

### DIFF
--- a/example/api2-samples/meson.build
+++ b/example/api2-samples/meson.build
@@ -7,6 +7,10 @@
 #libavcpp = subproject('avcpp')
 #avcpp_dep = libavcpp.get_variable('avcpp_dep')
 
+if not get_option('build_samples')
+   subdir_done()
+endif
+
 samples = [
     'api2-decode',
     'api2-decode-encode-video',

--- a/meson.build
+++ b/meson.build
@@ -4,25 +4,21 @@ project(
     meson_version: '>= 0.54.0',
     default_options : [
         'c_std=c11', 
-        'cpp_std=c++17'
+        'cpp_std=c++17',
+        'build_tests=@0@'.format(not meson.is_subproject()),
+        'build_samples=@0@'.format(not meson.is_subproject()),
     ],
     version: '2.0.99',
 )
 
-if not meson.is_subproject()
-    subdir('src')
+subdir('src')
+subdir('example/api2-samples')
+subdir('tests')
 
-    if get_option('build_samples')
-        subdir('example/api2-samples')
-    endif
+meson.override_dependency('avcpp', avcpp_dep)
 
-    if get_option('build_tests')
-        subdir('tests')
-    endif
-else
-    subdir('src')
-endif
-
-if meson.version().version_compare('>=0.54.0')
-    meson.override_dependency('avcpp', avcpp_dep)
-endif
+summary({
+    'Build samples' : get_option('build_samples'),
+    'Build tests' : get_option('build_tests')
+    }, section: 'Extra', bool_yn: true,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'avcpp',
     'cpp',
-    meson_version: '>= 0.50.0',
+    meson_version: '>= 0.54.0',
     default_options : [
         'c_std=c11', 
         'cpp_std=c++17'

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,9 @@
 #get catch2
+
+if not get_option('build_tests')
+    subdir_done()
+endif
+
 catch2 = dependency('catch2', required: true, fallback:['catch2','catch2_dep'])
 
 #create main_test as library and export the dependency


### PR DESCRIPTION
Hello

Currently when using as this library meson subproject I have no control over on weather tests and samples are built.

The first change bumps required meson version to 0.54.0 (ffmpeg on `meson-4.3` branch already requires it). This let me remove check for `meson.override_dependency()` and use 0.53.0 pretty `summary()`.
Second change leaves defaults as they were - when built as subproject it defaults to no tests and samples.
While now I can specify `-Davcpp:build_tests=true` in my master project to adjust it to my likeing.
