### PR TITLE
send/receive avcodec API compatibility

### DIFF
--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -21,16 +21,26 @@ bool Codec::canEncode() const
 #if LIBAVCODEC_VERSION_INT <= AV_VERSION_INT(54,23,100) // 0.11.1
     if (m_raw)
         return (m_raw->encode || m_raw->encode2);
-#else
+#elif LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100) // 7fc329e
     if (m_raw)
         return m_raw->encode2;
+#else
+    if (m_raw)
+        return (m_raw->receive_packet || m_raw->encode2);
 #endif
     return false;
 }
 
 bool Codec::canDecode() const
 {
-    return RAW_GET(decode, nullptr) != nullptr;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57,37,100) // 7fc329e
+    if (m_raw)
+        return m_raw->decode;
+#else
+    if (m_raw)
+        return (m_raw->receive_frame || m_raw->decode);
+#endif
+    return false;
 }
 
 AVMediaType Codec::type() const


### PR DESCRIPTION
Detect whether codec encodes or decodes by checking `receive_packet` and `receive_frame` fields.

Since FFmpeg 7fc329e, libavcodec has a new API for encoding and decoding. While avcpp already uses it in `src/codeccontext.cpp` in `encode` and `decode` functions, it still uses the old API for detection whether codec can encode and decode. This commit updates this detection.