### PR TITLE
fix problematic compound literal on msvc.

### DIFF
--- a/src/avutils.h
+++ b/src/avutils.h
@@ -42,7 +42,7 @@ namespace av {
 // Basic FFmpeg constants
 constexpr auto NoPts = static_cast<int64_t>(AV_NOPTS_VALUE);
 constexpr auto TimeBase = static_cast<int>(AV_TIME_BASE);
-constexpr auto TimeBaseQ = static_cast<AVRational>(AV_TIME_BASE_Q);
+constexpr auto TimeBaseQ = AVRational{1, AV_TIME_BASE};
 
 
 template<typename R, typename T>


### PR DESCRIPTION
msvc doesn't support compound literals in c++ mode (it does in C mode) thus the definition of TimeBaseQ was failing to compile. C++ has list initialization of temporaries anyway so we can just use that instead.