### PR TITLE
Adjust minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.19)
 
 if(NOT DEFINED PROJECT_NAME)
     set(AVCPP_NOT_SUBPROJECT ON)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can read the full documentation [here](https://h4tr3d.github.io/avcpp/).
   - libswresample >= 0.x.x
   - libpostproc >= 52.x.x
 - GCC >= 5.0 (C++11 is required)
-- CMake (> 3.11) or Meson(> 50.0)
+- CMake (> 3.19) or Meson(> 50.0)
 
 ### Debian, Ubuntu 19.10 and Linux Mint 20.x or newer
 

--- a/example/api2-samples/CMakeLists.txt
+++ b/example/api2-samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.11)
+cmake_minimum_required (VERSION 3.19)
 
 # transcoder sources
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.19)
 
 project(avcpp_tests LANGUAGES CXX VERSION 0.0.1)
 


### PR DESCRIPTION
This pull request changes the minimum required CMake version to 3.19 since with versions below that the project doesn't built due to an error (see issue #103)