### PR TITLE
fix audio example infinite loop

### DIFF
--- a/example/api2-samples/api2-decode-encode-audio.cpp
+++ b/example/api2-samples/api2-decode-encode-audio.cpp
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
                 break;
             }
 
-            if (pkt.streamIndex() != audioStream) {
+            if (pkt && pkt.streamIndex() != audioStream) {
                 continue;
             }
 


### PR DESCRIPTION
Fix the infinite loop at the end of the audio transcoding example