### PR TITLE
reference explicitly codecType which is not inherited

### DIFF
--- a/src/codeccontext.h
+++ b/src/codeccontext.h
@@ -254,7 +254,7 @@ public:
 
     AVMediaType codecType() const noexcept
     {
-        return codecType(_type);
+        return CodecContext2::codecType(_type);
     }
 };
 


### PR DESCRIPTION
`codecType` is not inherited (because of the overload I think?)