### PR TITLE
std::string_view cannot be constructed from nullptr

### DIFF
--- a/src/formatcontext.cpp
+++ b/src/formatcontext.cpp
@@ -39,6 +39,8 @@ int64_t custom_io_seek(void *opaque, int64_t offset, int whence)
 string_view get_uri(const AVFormatContext *ctx)
 {
 #if API_AVFORMAT_URL
+    if (ctx->url == nullptr)
+        return {};
     return ctx->url;
 #else
     return ctx->filename;


### PR DESCRIPTION
According to the C++ specs `std::string_view` cannot be constructed from `nullptr` and many compilers will produce a crashing code. Use the default constructor instead.

