### PR TITLE
Bug fix on `FilterGraph::filter`

### DIFF
--- a/src/filters/filtergraph.cpp
+++ b/src/filters/filtergraph.cpp
@@ -70,7 +70,7 @@ FilterContext FilterGraph::filter(unsigned idx, OptionalErrorCode ec)
         return FilterContext();
     }
 
-    if (idx < m_raw->nb_filters) {
+    if (idx >= m_raw->nb_filters) {
         throws_if(ec, Errors::OutOfRange);
         return FilterContext();
     }


### PR DESCRIPTION
 `nb_filters` means the count of the filters, `idx` should less than the count of the filters.