### PR TITLE
lookup for dependency Threads

### DIFF
--- a/src/Config.cmake.in
+++ b/src/Config.cmake.in
@@ -1,2 +1,5 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 @PACKAGE_INIT@
 include("${CMAKE_CURRENT_LIST_DIR}/avcpp-targets.cmake")


### PR DESCRIPTION
Fixes https://github.com/h4tr3d/avcpp/issues/135, missing lookup for dependency `Threads` in config file:
```
1> [CMake] CMake Error at build/debug/vcpkg_installed/x64-windows/share/avcpp/avcpp-targets.cmake:61 (set_target_properties):
1> [CMake]   The link interface of target "avcpp::avcpp" contains:
1> [CMake] 
1> [CMake]     Threads::Threads
1> [CMake] 
1> [CMake]   but the target was not found.  Possible reasons include:
1> [CMake] 
1> [CMake]     * There is a typo in the target name.
1> [CMake]     * A find_package call is missing for an IMPORTED target.
1> [CMake]     * An ALIAS target is missing.
1> [CMake] 
1> [CMake] Call Stack (most recent call first):
1> [CMake]   build/debug/vcpkg_installed/x64-windows/share/avcpp/avcpp-config.cmake:26 (include)
1> [CMake]   vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
1> [CMake]   CMakeLists.txt:16 (find_package)
```