### PR TITLE
fix isValid() for VAAPI frame

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -265,7 +265,10 @@ public:
     bool isComplete() const { return m_isComplete; }
 
     bool isValid() const {
-         return (!isNull() && (m_raw->data[0] && m_raw->linesize[0]) || ((m_raw->format == AV_PIX_FMT_VAAPI)));
+         return (!isNull() &&
+             ((m_raw->data[0] && m_raw->linesize[0]) ||
+             ((m_raw->format == AV_PIX_FMT_VAAPI) && ((intptr_t)m_raw->data[3] > 0)))
+         );
     }
 
     operator bool() const { return isValid() && isComplete(); }

--- a/src/frame.h
+++ b/src/frame.h
@@ -264,7 +264,9 @@ public:
 
     bool isComplete() const { return m_isComplete; }
 
-    bool isValid() const { return (!isNull() && m_raw->data[0] && m_raw->linesize[0]); }
+    bool isValid() const {
+         return (!isNull() && (m_raw->data[0] && m_raw->linesize[0]) || ((m_raw->format == AV_PIX_FMT_VAAPI)));
+    }
 
     operator bool() const { return isValid() && isComplete(); }
 


### PR DESCRIPTION
fix frame isValid() method for frames returned from VAAPI decoder.
In this case m_raw->data[0] and m_raw->linesize[0] are both null and m_raw[3] contains vaapi surface id (valid when > 0).