### PR TITLE
Only set C++ standard if not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ set(AV_ENABLE_STATIC On CACHE BOOL "Enable static library build (On)")
 set(AV_ENABLE_SHARED On CACHE BOOL "Enable shared library build (On)")
 set(AV_BUILD_EXAMPLES On CACHE BOOL "Build example applications (On)")
 
-# Compiler-specific C++11 activation.
-set(CMAKE_CXX_STANDARD 17)
+# Compiler-specific C++17 activation.
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED yes)
 
 # Warnings


### PR DESCRIPTION
This allows us use `add_subdirectory(avcpp)` without overwriting the set standard (C++23 e.g.)