### PR TITLE
Cmake patches

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,7 +137,7 @@ if (AVCPP_NOT_SUBPROJECT)
             )
 
         install(FILES   "${CMAKE_CURRENT_BINARY_DIR}/libavcpp.pc"
-            DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig")
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
     endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,10 @@ foreach(TARGET ${AV_TARGETS})
       target_link_libraries(${TARGET} PRIVATE ws2_32)
     endif()
 
+    if(MSVC AND TYPE STREQUAL "SHARED")
+        set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+    endif()
+
     add_library(${AV_NAMESPACE}::${TARGET} ALIAS ${TARGET})
 endforeach()
 


### PR DESCRIPTION
This fixes some of the issues from #68 for improved vcpkg support and Windows shared DLLs support.