### PR TITLE
Fix MKV hw encode issue

### DIFF
--- a/example/api2-samples/api2-hw-encode.cpp
+++ b/example/api2-samples/api2-hw-encode.cpp
@@ -3,8 +3,6 @@
  *
  * Thanks to https://github.com/mojie126, for more-less complete sample.
  *
- * Known issues: error on the Matroska header writing.
- *
  */
 
 
@@ -154,6 +152,11 @@ int main(int argc, char **argv) {
         encoder.setPixelFormat(vdec.pixelFormat());
     encoder.setTimeBase(Rational{1, 1000});
     encoder.setBitRate(vdec.bitRate());
+
+    // MKV format wants global header, so
+    // this fixes the issue with MKV container
+    if (ofrmt.raw()->flags & AVFMT_GLOBALHEADER)
+        encoder.raw()->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
     encoder.open(Codec(), ec);
     if (ec) {


### PR DESCRIPTION
I stumbled upon this same issue when implementing my own HW encoder-decoder demo with FFmpeg, and these two lines seem to be able to fix it. Currently, I'm just patching it manually using the raw C structures, but we might want a better way to do it. 