### PR TITLE
more generic filter example that also encodes the result

### DIFF
--- a/example/api2-samples/CMakeLists.txt
+++ b/example/api2-samples/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TARGETS
   api2-decode-audio
   api2-decode-rasample-audio
   api2-decode-encode-audio
+  api2-decode-filter-encode
   api2-dict-basic
   api2-timestamp
   api2-demux-seek

--- a/example/api2-samples/meson.build
+++ b/example/api2-samples/meson.build
@@ -14,6 +14,7 @@ samples = [
     'api2-decode-audio',
     'api2-decode-rasample-audio',
     'api2-decode-encode-audio',
+    'api2-decode-filter-encode',
     'api2-dict-basic',
     'api2-timestamp',
     'api2-demux-seek',


### PR DESCRIPTION
This improved example also encodes the result and handles correctly streams that require the full input before producing any output (`palettegen` in this case) 

It also adds the example to the makefiles