### PR TITLE
Fix custom header/libraray path

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -126,7 +126,6 @@ macro(find_component _component _pkgconfig _library _header)
     find_path(${_component}_INCLUDE_DIRS ${_header}
             PATHS ${PC_FFMPEG_INCLUDE_DIRS}
             NO_DEFAULT_PATH
-            REQUIRED
     )
   else ()
     find_path(${_component}_INCLUDE_DIRS ${_header}


### PR DESCRIPTION
This PR aims to resolve this issue: 
https://github.com/h4tr3d/avcpp/issues/157
In order to resolve it, i conditionally check whether `PC_FFMPEG_LIBRARY_DIRS` and `PC_FFMPEG_INCLUDE_DIRS` are present. If library is found, it sets the variables manually:
```cmake
        set(${_component}_LIBRARY_DIRS ${PC_FFMPEG_LIBRARY_DIRS} CACHE STRING "The ${_component} library dirs.")
        set(${_component}_LIBRARIES ${_library} CACHE STRING "The ${_component} libraries.")
```
I'm almost certain this also should be checked and set manually in case `PC_FFMPEG_INCLUDE_DIRS` is present:
```cmake
      find_path(${_component}_INCLUDE_DIRS ${_header}
            HINTS
            ${PC_${_component}_INCLUDEDIR}
            ${PC_${_component}_INCLUDE_DIRS}
            ${PC_FFMPEG_INCLUDE_DIRS}
            PATH_SUFFIXES
            ffmpeg
    )
```
like this:     
   ```cmake
       find_path(${_component}_INCLUDE_DIRS ${_header}
            PATHS
            ${PC_FFMPEG_INCLUDE_DIRS}
            NO_DEFAULT_PATH
            REQUIRED # perhaps?
   )
   ```
   
About formatting. I didn't find any cmake-format configs in the repo. Because of this, cmake-formatter with my own settings was applied. I'm not even sure how to format  this exact cmake file. 
Any suggestions are appreciated! 
    