### PR TITLE
Fix compilation against FFmpeg 3.x

### DIFF
--- a/src/formatcontext.cpp
+++ b/src/formatcontext.cpp
@@ -9,6 +9,13 @@
 #include "codeccontext.h"
 #include "codecparameters.h"
 
+#if !API_AVFORMAT_URL
+extern "C"
+{
+  #include <libavutil/avstring.h>
+}
+#endif
+
 using namespace std;
 
 namespace {
@@ -60,7 +67,7 @@ void set_uri(AVFormatContext *ctx, string_view uri)
             av_free(ctx->url);
         ctx->url = av_strdup(uri.data());
 #else
-        av_strlcpy(ctx->filename, uri.data(), std::min<size_t>(sizeof(m_raw->filename), uri.size() + 1));
+        av_strlcpy(ctx->filename, uri.data(), std::min<size_t>(sizeof(ctx->filename), uri.size() + 1));
         ctx->filename[uri.size()] = '\0';
 #endif
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ enable_testing()
 #(Catch2 REQUIRED)
 
 add_library(test_main STATIC test-main.cpp)
-target_link_libraries(test_main PUBLIC Catch2::Catch2)
+target_link_libraries(test_main PUBLIC Catch2::Catch2 avcpp::avcpp)
 
 add_executable(test_executor
     Frame.cpp

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,7 +5,7 @@ catch2 = dependency('catch2', required: true, fallback:['catch2','catch2_dep'])
 main_test = static_library(
     'main_test', 
     'test-main.cpp', 
-    dependencies: catch2
+    dependencies: [catch2, avcpp_dep]
 )
 
 main_test_dep = declare_dependency(

--- a/tests/test-main.cpp
+++ b/tests/test-main.cpp
@@ -1,10 +1,17 @@
 // In a Catch project with multiple files, dedicate one file to compile the
 // source code of Catch itself and reuse the resulting object file for linking.
 
-// Let Catch provide main():
-#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_RUNNER
 
 #include <catch2/catch.hpp>
+
+#include "av.h"
+
+int main(int argc, char* argv[])
+{
+    av::init();
+    return Catch::Session().run(argc, argv);
+}
 
 // That's it
 


### PR DESCRIPTION
* Fix compilation of formatcontext.cpp when API_AVFORMAT_URL is undefined

* Fix segfault in unit tests by calling av::init() before test execution