### PR TITLE
Explicit symbol visibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(GNUInstallDirs)
+include(GenerateExportHeader)
 
 file(GLOB_RECURSE AV_SOURCES "avcpp/*.cpp")
 file(GLOB_RECURSE AV_HEADERS "avcpp/*.h" "avcpp/*.hpp")
@@ -58,7 +59,7 @@ foreach(TARGET ${AV_TARGETS})
         #PRIVATE
         #  ${CMAKE_CURRENT_SOURCE_DIR}
       )
-    set_target_properties(${TARGET} PROPERTIES PUBLIC_HEADER "${AV_HEADERS};${CMAKE_CURRENT_BINARY_DIR}/avcpp/avconfig.h")
+    set_target_properties(${TARGET} PROPERTIES PUBLIC_HEADER "${AV_HEADERS};${CMAKE_CURRENT_BINARY_DIR}/avcpp/avconfig.h;${CMAKE_CURRENT_BINARY_DIR}/avcpp/avcpp_export.h")
 
     # If not CMAKE_CXX_STANARD provided globally (subproject), use latest supported one
     if (NOT CMAKE_CXX_STANDARD)
@@ -83,15 +84,35 @@ foreach(TARGET ${AV_TARGETS})
       target_link_libraries(${TARGET} PRIVATE ws2_32)
     endif()
 
-    if(MSVC AND TYPE STREQUAL "SHARED")
-        set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-    endif()
-
     add_library(${AV_NAMESPACE}::${TARGET} ALIAS ${TARGET})
 endforeach()
 
 if (TARGET ${AV_BASENAME}-static)
     set_target_properties(${AV_BASENAME}-static PROPERTIES OUTPUT_NAME ${AV_BASENAME})
+endif()
+
+# prepare export header for visibility macros
+string(TOUPPER ${AV_BASENAME} AV_BASENAME_UPPER)
+generate_export_header(${AV_BASENAME}
+    EXPORT_FILE_NAME    ${CMAKE_CURRENT_BINARY_DIR}/avcpp/avcpp_export.h
+    STATIC_DEFINE       ${AV_BASENAME_UPPER}_STATIC_DEFINE
+)
+if (AV_ENABLE_SHARED)
+    set_target_properties(${AV_BASENAME} PROPERTIES
+        CXX_VISIBILITY_PRESET    hidden
+        C_VISIBILITY_PRESET      hidden
+        VISIBILITY_INLINES_HIDDEN ON
+    )
+
+    if (TARGET ${AV_BASENAME}-static)
+        target_compile_definitions(${AV_BASENAME}-static PUBLIC
+            ${AV_BASENAME_UPPER}_STATIC_DEFINE
+        )
+    endif()
+else()
+    target_compile_definitions(${AV_BASENAME} PUBLIC
+        ${AV_BASENAME_UPPER}_STATIC_DEFINE
+    )
 endif()
 
 # prepare configuration file
@@ -191,7 +212,6 @@ if (AVCPP_NOT_SUBPROJECT)
 
         install(FILES   "${CMAKE_CURRENT_BINARY_DIR}/avcpp/libavcpp.pc"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
-
     endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,7 +158,7 @@ if (AVCPP_NOT_SUBPROJECT)
           "${CMAKE_CURRENT_BINARY_DIR}/avcpp/avcpp-config.cmake"
           "${CMAKE_CURRENT_BINARY_DIR}/avcpp/avcpp-config-version.cmake"
         DESTINATION
-          "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/avcpp"
+          "${CMAKE_INSTALL_LIBDIR}/cmake/avcpp"
       )
 
     if (PKG_CONFIG_FOUND)

--- a/src/avcpp/audioresampler.h
+++ b/src/avcpp/audioresampler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <functional>
 
 #include "ffmpeg.h"
@@ -13,7 +15,7 @@ namespace av {
 
 // TODO: support New Channel Layout directly
 
-class AudioResampler : public FFWrapperPtr<SwrContext>, public noncopyable
+class AVCPP_EXPORT AudioResampler : public FFWrapperPtr<SwrContext>, public noncopyable
 {
 public:
     AudioResampler();

--- a/src/avcpp/av.h
+++ b/src/avcpp/av.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 namespace av {
 
 /**
  * Init all subsustems needed by avcpp. Must be call before any other functionality
  */
-void init();
+AVCPP_EXPORT void init();
 
 } // ::av
 

--- a/src/avcpp/averror.h
+++ b/src/avcpp/averror.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <system_error>
 #include <exception>
 
@@ -62,7 +64,7 @@ enum class Errors
     MixBufferSinkAccess,
 };
 
-class OptionalErrorCode
+class AVCPP_EXPORT OptionalErrorCode
 {
     OptionalErrorCode() {}
 
@@ -85,7 +87,7 @@ private:
  *
  * Simple wrap error code value and category
  */
-class Exception : public std::system_error
+class AVCPP_EXPORT Exception : public std::system_error
 {
 public:
     using std::system_error::system_error;
@@ -95,7 +97,7 @@ public:
  * @brief The AvcppCategory class
  * Describes internal AvCpp errors
  */
-class AvcppCategory : public std::error_category
+class AVCPP_EXPORT AvcppCategory : public std::error_category
 {
 public:
 
@@ -107,7 +109,7 @@ public:
  * @brief The FfmpegCategory class
  * Describers FFmpeg internal errors
  */
-class FfmpegCategory : public std::error_category
+class AVCPP_EXPORT FfmpegCategory : public std::error_category
 {
     virtual const char *name() const noexcept override;
     virtual std::string message(int ev) const override;

--- a/src/avcpp/avtime.h
+++ b/src/avcpp/avtime.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include "ffmpeg.h"
 
 namespace av {
@@ -7,7 +9,7 @@ namespace av {
 /**
  * Get the current time in microseconds.
  */
-int64_t gettime();
+AVCPP_EXPORT int64_t gettime();
 
 
 /**
@@ -18,7 +20,7 @@ int64_t gettime();
  * @param  usec Number of microseconds to sleep.
  * @return zero on success or (negative) error code.
  */
-int usleep(unsigned usec);
+AVCPP_EXPORT int usleep(unsigned usec);
 
 
 } // ::av

--- a/src/avcpp/avutils.h
+++ b/src/avcpp/avutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "avcpp/avconfig.h"
+#include "avcpp/avcpp_export.h"
 
 #include <ranges>
 #include <string>
@@ -48,7 +49,7 @@ R lexical_cast(const T& v)
     return result;
 }
 
-class noncopyable
+class AVCPP_EXPORT noncopyable
 {
 protected:
     noncopyable() = default;
@@ -63,7 +64,7 @@ protected:
  *               mean less logging.  A negative number tells FFmpeg to
  *               shut up.
  */
-void set_logging_level(int32_t level);
+AVCPP_EXPORT void set_logging_level(int32_t level);
 
 
 /**
@@ -75,7 +76,7 @@ void set_logging_level(int32_t level);
  *                boost::lexical_cast will be used and set_logging_level(int32_t) will be
  *                called.
  */
-void set_logging_level(const std::string& level);
+AVCPP_EXPORT void set_logging_level(const std::string& level);
 
 // Compat code
 #define setFFmpegLoggingLevel set_logging_level
@@ -88,7 +89,7 @@ void set_logging_level(const std::string& level);
  * @param width         output width in hex values (real text screen with is: sw = width * 3 - 1)
  */
 [[deprecated("Use av::hex_dump()")]]
-void dumpBinaryBuffer(uint8_t *buffer, int buffer_size, int width = 16);
+AVCPP_EXPORT void dumpBinaryBuffer(uint8_t *buffer, int buffer_size, int width = 16);
 
 
 /**
@@ -96,7 +97,7 @@ void dumpBinaryBuffer(uint8_t *buffer, int buffer_size, int width = 16);
  * @param error - error code to convert to string
  * @return string representation of error code
  */
-std::string error2string(int error);
+AVCPP_EXPORT std::string error2string(int error);
 
 }
 
@@ -108,7 +109,7 @@ std::string error2string(int error);
 //
 namespace av {
 
-struct EmptyDeleter
+struct AVCPP_EXPORT EmptyDeleter
 {
     void operator()(void *) {}
 };
@@ -119,7 +120,7 @@ struct EmptyDeleter
  * Can be used with shared_ptr<> and so on.
  */
 namespace v1 {
-struct AvDeleter
+struct AVCPP_EXPORT AvDeleter
 {
     bool operator() (struct SwsContext* &swsContext);
     bool operator() (struct AVCodecContext* &codecContext);
@@ -138,7 +139,7 @@ struct AvDeleter
 } // ::v1
 
 inline namespace v2 {
-struct SmartDeleter
+struct AVCPP_EXPORT SmartDeleter
 {
     template<typename T>
     bool operator() (T *ptr) {
@@ -169,7 +170,7 @@ std::unique_ptr<T, void(*)(void*)> memdup(const void *p, size_t size)
  * Functor to take next element in list/array
  */
 #if 0
-struct AvNextElement
+struct AVCPP_EXPORT AvNextElement
 {
     AVFilterInOut * operator()(AVFilterInOut * x) const
     {
@@ -261,7 +262,7 @@ private:
  * In example above dtor of the action will be called before fd and we correctly close descriptor.
  *
  */
-class ScopeOutAction
+class AVCPP_EXPORT ScopeOutAction
 {
 public:
     template<typename Proc>
@@ -628,12 +629,12 @@ void array_to_container(const T* array, Container &container, Compare isEnd, Cal
 //
 // Allow to use without AVFORMAT library
 //
-void hex_dump(FILE *f, const uint8_t *buf, std::size_t size);
-void hex_dump_log(void *avcl, int level, const uint8_t *buf, std::size_t size);
+AVCPP_EXPORT void hex_dump(FILE *f, const uint8_t *buf, std::size_t size);
+AVCPP_EXPORT void hex_dump_log(void *avcl, int level, const uint8_t *buf, std::size_t size);
 
 #if AVCPP_CXX_STANDARD >= 20
-void hex_dump(FILE *f, std::span<const uint8_t> buf);
-void hex_dump_log(void *avcl, int level, std::span<const uint8_t> buf);
+AVCPP_EXPORT void hex_dump(FILE *f, std::span<const uint8_t> buf);
+AVCPP_EXPORT void hex_dump_log(void *avcl, int level, std::span<const uint8_t> buf);
 #endif // if AVCPP_CXX_STANDARD >= 20
 
 } // ::av

--- a/src/avcpp/buffer.h
+++ b/src/avcpp/buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
 #include "avcpp/averror.h"
 #include "ffmpeg.h"
 
@@ -13,7 +14,7 @@ namespace buffer {
 /**
  * Buffer deleter that do nothing. To wrap static data.
  */
-void null_deleter(void* /*opaque*/, uint8_t* /*data*/);
+AVCPP_EXPORT void null_deleter(void* /*opaque*/, uint8_t* /*data*/);
 } // ::buffer
 
 class BufferRef;
@@ -21,7 +22,7 @@ class BufferRef;
 /**
  * Non-owning view for the nested AVBufferRef
  */
-class BufferRefView : public FFWrapperPtr<AVBufferRef>
+class AVCPP_EXPORT BufferRefView : public FFWrapperPtr<AVBufferRef>
 {
 public:
     using FFWrapperPtr<AVBufferRef>::FFWrapperPtr;
@@ -115,7 +116,7 @@ public:
 /**
  * Light weight wrapper for the FFmpeg AVBufferRef functionality
  */
-class BufferRef : public BufferRefView
+class AVCPP_EXPORT BufferRef : public BufferRefView
 {
     //using FFWrapperPtr<AVBufferRef>::FFWrapperPtr;
     using BufferRefView::BufferRefView;

--- a/src/avcpp/channellayout.h
+++ b/src/avcpp/channellayout.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <string>
 #include <string_view>
 #include <bitset>
@@ -14,14 +16,14 @@ extern "C" {
 
 namespace av {
 
-std::string channel_name(AVChannel channel);
-std::string channel_description(AVChannel channel);
-AVChannel   channel_from_string(const std::string &name);
-AVChannel   channel_from_string(const char *name);
+AVCPP_EXPORT std::string channel_name(AVChannel channel);
+AVCPP_EXPORT std::string channel_description(AVChannel channel);
+AVCPP_EXPORT AVChannel   channel_from_string(const std::string &name);
+AVCPP_EXPORT AVChannel   channel_from_string(const char *name);
 
 class ChannelLayout;
 
-class ChannelLayoutView
+class AVCPP_EXPORT ChannelLayoutView
 {
 public:
     ChannelLayoutView() noexcept;
@@ -77,7 +79,7 @@ protected:
 
 
 
-class ChannelLayout : public ChannelLayoutView
+class AVCPP_EXPORT ChannelLayout : public ChannelLayoutView
 {
 public:
     ChannelLayout() = default;

--- a/src/avcpp/codec.h
+++ b/src/avcpp/codec.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <list>
 #include <deque>
 #include <memory>
@@ -14,7 +16,7 @@
 
 namespace av {
 
-class Codec : public FFWrapperPtr<const AVCodec>
+class AVCPP_EXPORT Codec : public FFWrapperPtr<const AVCodec>
 {
 public:
     using FFWrapperPtr<const AVCodec>::FFWrapperPtr;
@@ -42,15 +44,15 @@ public:
 
 
 
-Codec findEncodingCodec(AVCodecID id);
-Codec findEncodingCodec(const std::string& name);
+AVCPP_EXPORT Codec findEncodingCodec(AVCodecID id);
+AVCPP_EXPORT Codec findEncodingCodec(const std::string& name);
 
-Codec findDecodingCodec(AVCodecID id);
-Codec findDecodingCodec(const std::string& name);
+AVCPP_EXPORT Codec findDecodingCodec(AVCodecID id);
+AVCPP_EXPORT Codec findDecodingCodec(const std::string& name);
 
 #if AVCPP_HAS_AVFORMAT
-Codec findEncodingCodec(const OutputFormat &format, bool isVideo = true);
-Codec guessEncodingCodec(OutputFormat format, const char *name, const char *url, const char* mime, AVMediaType mediaType);
+AVCPP_EXPORT Codec findEncodingCodec(const OutputFormat &format, bool isVideo = true);
+AVCPP_EXPORT Codec guessEncodingCodec(OutputFormat format, const char *name, const char *url, const char* mime, AVMediaType mediaType);
 #endif // if AVCPP_HAS_AVFORMAT
 
 } // ::fmpeg

--- a/src/avcpp/codeccontext.h
+++ b/src/avcpp/codeccontext.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include "avcompat.h"
 
 #include "ffmpeg.h"
@@ -20,17 +22,17 @@ extern "C" {
 namespace av {
 
 namespace codec_context::audio {
-void set_channels(AVCodecContext *obj, int channels);
-void set_channel_layout_mask(AVCodecContext *obj, uint64_t mask);
-int get_channels(const AVCodecContext *obj);
-uint64_t get_channel_layout_mask(const AVCodecContext *obj);
+AVCPP_EXPORT void set_channels(AVCodecContext *obj, int channels);
+AVCPP_EXPORT void set_channel_layout_mask(AVCodecContext *obj, uint64_t mask);
+AVCPP_EXPORT int get_channels(const AVCodecContext *obj);
+AVCPP_EXPORT uint64_t get_channel_layout_mask(const AVCodecContext *obj);
 }
 
 namespace codec_context::internal {
-const int *get_supported_samplerates(const struct AVCodec *codec);
+AVCPP_EXPORT const int *get_supported_samplerates(const struct AVCodec *codec);
 }
 
-class CodecContext2 : public FFWrapperPtr<AVCodecContext>, public noncopyable
+class AVCPP_EXPORT CodecContext2 : public FFWrapperPtr<AVCodecContext>, public noncopyable
 {
 protected:
     void swap(CodecContext2 &other);
@@ -187,7 +189,7 @@ private:
  * encoding coder.
  *
  */
-class GenericCodecContext : public CodecContext2
+class AVCPP_EXPORT GenericCodecContext : public CodecContext2
 {
 protected:
     using CodecContext2::codecType;
@@ -398,7 +400,7 @@ protected:
 };
 
 
-class VideoDecoderContext : public VideoCodecContext<VideoDecoderContext, Direction::Decoding>
+class AVCPP_EXPORT VideoDecoderContext : public VideoCodecContext<VideoDecoderContext, Direction::Decoding>
 {
 public:
     using Parent = VideoCodecContext<VideoDecoderContext, Direction::Decoding>;
@@ -454,7 +456,7 @@ private:
 };
 
 
-class VideoEncoderContext : public VideoCodecContext<VideoEncoderContext, Direction::Encoding>
+class AVCPP_EXPORT VideoEncoderContext : public VideoCodecContext<VideoEncoderContext, Direction::Encoding>
 {
 public:
     using Parent = VideoCodecContext<VideoEncoderContext, Direction::Encoding>;
@@ -587,7 +589,7 @@ protected:
 };
 
 
-class AudioDecoderContext : public AudioCodecContext<AudioDecoderContext, Direction::Decoding>
+class AVCPP_EXPORT AudioDecoderContext : public AudioCodecContext<AudioDecoderContext, Direction::Decoding>
 {
 public:
     using Parent = AudioCodecContext<AudioDecoderContext, Direction::Decoding>;
@@ -604,7 +606,7 @@ public:
 };
 
 
-class AudioEncoderContext : public AudioCodecContext<AudioEncoderContext, Direction::Encoding>
+class AVCPP_EXPORT AudioEncoderContext : public AudioCodecContext<AudioEncoderContext, Direction::Encoding>
 {
 public:
     using Parent = AudioCodecContext<AudioEncoderContext, Direction::Encoding>;

--- a/src/avcpp/codecparameters.h
+++ b/src/avcpp/codecparameters.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include "averror.h"
 #include "ffmpeg.h"
 #include "avutils.h"
@@ -24,7 +26,7 @@ enum class Direction
  *
  * Not-owned wrapper for AVCodecParameters. Do not keep for a long time.
  */
-class CodecParametersView : public FFWrapperPtr<AVCodecParameters>
+class AVCPP_EXPORT CodecParametersView : public FFWrapperPtr<AVCodecParameters>
 {
 public:
     CodecParametersView(AVCodecParameters *codecpar = nullptr);
@@ -58,7 +60,7 @@ public:
     // TBD
 };
 
-class CodecParameters : public CodecParametersView, public noncopyable
+class AVCPP_EXPORT CodecParameters : public CodecParametersView, public noncopyable
 {
 public:
     CodecParameters();

--- a/src/avcpp/dictionary.h
+++ b/src/avcpp/dictionary.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <tuple>
 #include <memory>
 #include <iterator>
@@ -27,7 +29,7 @@ namespace av {
  * This class also provide way to controll owning: you can create entity that does not owning data but
  * provide access to them. You can drop owning by release() call.
  */
-class Dictionary : public FFWrapperPtr<AVDictionary>
+class AVCPP_EXPORT Dictionary : public FFWrapperPtr<AVDictionary>
 {
 public:
     /**
@@ -130,7 +132,7 @@ public:
     /**
      * Dictionary key and value holder and accessor
      */
-    class Entry
+    class AVCPP_EXPORT Entry
     {
     public:
 
@@ -181,8 +183,8 @@ public:
          */
         bool isNull() const;
 
-        friend bool operator==(const Entry& lhs, const Entry& rhs);
-        friend bool operator!=(const Entry& lhs, const Entry& rhs);
+        AVCPP_EXPORT friend bool operator==(const Entry& lhs, const Entry& rhs);
+        AVCPP_EXPORT friend bool operator!=(const Entry& lhs, const Entry& rhs);
 
     private:
         AVDictionaryEntry *m_entry = nullptr;
@@ -585,7 +587,7 @@ private:
  *
  * It is not iterator-friendly and must not be used generally.
  */
-class DictionaryArray
+class AVCPP_EXPORT DictionaryArray
 {
 public:
 

--- a/src/avcpp/ffmpeg.h
+++ b/src/avcpp/ffmpeg.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <iostream>
 
 #include "avcompat.h"

--- a/src/avcpp/filters/buffersink.h
+++ b/src/avcpp/filters/buffersink.h
@@ -16,7 +16,7 @@
 
 namespace av {
 
-class BufferSinkFilterContext
+class AVCPP_EXPORT BufferSinkFilterContext
 {
     // To protect access
     enum {

--- a/src/avcpp/filters/buffersrc.h
+++ b/src/avcpp/filters/buffersrc.h
@@ -13,7 +13,7 @@
 
 namespace av {
 
-class BufferSrcFilterContext
+class AVCPP_EXPORT BufferSrcFilterContext
 {
 public:
     BufferSrcFilterContext() = default;

--- a/src/avcpp/filters/filter.h
+++ b/src/avcpp/filters/filter.h
@@ -21,7 +21,7 @@ enum class FilterMediaType
 };
 
 
-class Filter : public FFWrapperPtr<const AVFilter>
+class AVCPP_EXPORT Filter : public FFWrapperPtr<const AVFilter>
 {
 public:
     using FFWrapperPtr<const AVFilter>::FFWrapperPtr;

--- a/src/avcpp/filters/filtercontext.h
+++ b/src/avcpp/filters/filtercontext.h
@@ -12,7 +12,7 @@
 
 namespace av {
 
-class FilterContext : public FFWrapperPtr<AVFilterContext>
+class AVCPP_EXPORT FilterContext : public FFWrapperPtr<AVFilterContext>
 {
     friend class FilterGraph;
 

--- a/src/avcpp/filters/filtergraph.h
+++ b/src/avcpp/filters/filtergraph.h
@@ -14,7 +14,7 @@
 
 namespace av {
 
-class FilterGraph : FFWrapperPtr<AVFilterGraph>
+class AVCPP_EXPORT FilterGraph : FFWrapperPtr<AVFilterGraph>
 {
     friend class FilterInOut;
 

--- a/src/avcpp/filters/filterpad.h
+++ b/src/avcpp/filters/filterpad.h
@@ -11,7 +11,7 @@
 
 namespace av {
 
-class FilterPadList : public FFWrapperPtr<const AVFilterPad>
+class AVCPP_EXPORT FilterPadList : public FFWrapperPtr<const AVFilterPad>
 {
 private:
     friend class Filter;

--- a/src/avcpp/format.h
+++ b/src/avcpp/format.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <memory>
 #include <string>
 
@@ -24,8 +26,8 @@ using avcpp_format_const = typename std::conditional<
 
 using FmtCodec = class Codec;
 namespace internal {
-bool codec_supported(const AVCodecTag *const *codecTag, const FmtCodec &codec);
-bool codec_supported(const AVCodecTag *const *codecTag, AVCodecID codec_id);
+AVCPP_EXPORT bool codec_supported(const AVCodecTag *const *codecTag, const FmtCodec &codec);
+AVCPP_EXPORT bool codec_supported(const AVCodecTag *const *codecTag, AVCodecID codec_id);
 } // ::internal
 
 template<typename T>
@@ -74,7 +76,7 @@ protected:
     using FFWrapperPtr<T>::m_raw;
 };
 
-class InputFormat : public Format<avcpp_format_const<AVInputFormat>>
+class AVCPP_EXPORT InputFormat : public Format<avcpp_format_const<AVInputFormat>>
 {
 public:
     using Format<avcpp_format_const<AVInputFormat>>::Format;
@@ -89,7 +91,7 @@ public:
 };
 
 
-class OutputFormat : public Format<avcpp_format_const<AVOutputFormat>>
+class AVCPP_EXPORT OutputFormat : public Format<avcpp_format_const<AVOutputFormat>>
 {
 public:
     using Format<avcpp_format_const<AVOutputFormat>>::Format;
@@ -110,7 +112,7 @@ public:
 };
 
 
-OutputFormat guessOutputFormat(const std::string& name,
+AVCPP_EXPORT OutputFormat guessOutputFormat(const std::string& name,
                                const std::string& url  = std::string(),
                                const std::string& mime = std::string());
 

--- a/src/avcpp/formatcontext.h
+++ b/src/avcpp/formatcontext.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <memory>
 #include <chrono>
 #include <functional>
@@ -39,7 +41,7 @@ using AvioInterruptCb = std::function<int()>;
  * CustomIO object is not owned by the av::FormatContext and must be alived across av::FormatContext life.
  *
  */
-struct CustomIO
+struct AVCPP_EXPORT CustomIO
 {
     virtual ~CustomIO() {}
 
@@ -124,7 +126,7 @@ struct CustomIO
     virtual const char* name() const { return ""; }
 };
 
-class FormatContext : public FFWrapperPtr<AVFormatContext>, public noncopyable
+class AVCPP_EXPORT FormatContext : public FFWrapperPtr<AVFormatContext>, public noncopyable
 {
 #if AVCPP_CXX_STANDARD >= 20
     struct _StreamTransform {

--- a/src/avcpp/frame.h
+++ b/src/avcpp/frame.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <vector>
 
 #include "avcompat.h"
@@ -28,16 +30,16 @@ namespace av
 
 namespace frame
 {
-int64_t get_best_effort_timestamp(const AVFrame* frame);
-uint64_t get_channel_layout(const AVFrame* frame);
-void set_channel_layout(AVFrame* frame, uint64_t layout);
+AVCPP_EXPORT int64_t get_best_effort_timestamp(const AVFrame* frame);
+AVCPP_EXPORT uint64_t get_channel_layout(const AVFrame* frame);
+AVCPP_EXPORT void set_channel_layout(AVFrame* frame, uint64_t layout);
 } // ::av::frame
 
 #if AVCPP_HAS_FRAME_SIDE_DATA
 /**
  * Simple view for the AVFrameSideData elements
  */
-class FrameSideData : public FFWrapperPtr<AVFrameSideData>
+class AVCPP_EXPORT FrameSideData : public FFWrapperPtr<AVFrameSideData>
 {
 public:
     using FFWrapperPtr<AVFrameSideData>::FFWrapperPtr;
@@ -67,7 +69,7 @@ public:
 };
 #endif // AVCPP_HAS_PKT_SIDE_DATA
 
-class FrameCommon : public FFWrapperPtr<AVFrame>
+class AVCPP_EXPORT FrameCommon : public FFWrapperPtr<AVFrame>
 {
 public:
     /**
@@ -257,7 +259,7 @@ static_assert(std::is_copy_constructible_v<FrameCommon> == true);
 static_assert(std::is_move_assignable_v<FrameCommon> == false);
 static_assert(std::is_move_constructible_v<FrameCommon> == true);
 
-class VideoFrame : public Frame<VideoFrame>
+class AVCPP_EXPORT VideoFrame : public Frame<VideoFrame>
 {
 public:
     using Frame<VideoFrame>::Frame;
@@ -367,7 +369,7 @@ static_assert(std::is_copy_constructible_v<VideoFrame> == true);
 static_assert(std::is_move_assignable_v<VideoFrame> == true);
 static_assert(std::is_move_constructible_v<VideoFrame> == true);
 
-class AudioSamples : public Frame<AudioSamples>
+class AVCPP_EXPORT AudioSamples : public Frame<AudioSamples>
 {
 public:
     using Frame<AudioSamples>::Frame;

--- a/src/avcpp/packet.h
+++ b/src/avcpp/packet.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include "avcompat.h"
 
 #include <vector>
@@ -26,7 +28,7 @@ namespace av {
 /**
  * Simple view for the AVPacketSideData elements
  */
-class PacketSideData : public FFWrapperRef<AVPacketSideData>
+class AVCPP_EXPORT PacketSideData : public FFWrapperRef<AVPacketSideData>
 {
 public:
     using FFWrapperRef<AVPacketSideData>::FFWrapperRef;
@@ -43,7 +45,7 @@ public:
 };
 #endif // AVCPP_HAS_PKT_SIDE_DATA
 
-class Packet :
+class AVCPP_EXPORT Packet :
 #if AVCPP_API_AVCODEC_NEW_INIT_PACKET
     public FFWrapperPtr<AVPacket>
 #else

--- a/src/avcpp/pixelformat.h
+++ b/src/avcpp/pixelformat.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <string>
 #include <iostream>
 
@@ -23,7 +25,7 @@ namespace av {
  *
  * It has size same to the AVPixelFormat, but wrap pixel description function too.
  */
-class PixelFormat : public PixSampleFmtWrapper<PixelFormat, AVPixelFormat>
+class AVCPP_EXPORT PixelFormat : public PixSampleFmtWrapper<PixelFormat, AVPixelFormat>
 {
 public:
     using Parent = PixSampleFmtWrapper<PixelFormat, AVPixelFormat>;

--- a/src/avcpp/rational.h
+++ b/src/avcpp/rational.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <utility>
 #include <iostream>
 #include <memory>
@@ -22,7 +24,7 @@ enum
     RationalMaxPrecision = 5
 };
 
-class Rational
+class AVCPP_EXPORT Rational
 {
 public:
     Rational() noexcept;

--- a/src/avcpp/rect.h
+++ b/src/avcpp/rect.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 namespace av {
 
-class Rect
+class AVCPP_EXPORT Rect
 {
 public:
     Rect() noexcept = default;

--- a/src/avcpp/sampleformat.h
+++ b/src/avcpp/sampleformat.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <iostream>
 #include <string>
 
@@ -18,7 +20,7 @@ namespace av {
  * It allows to quckly ask some info about sample format. Only base one is provided.
  *
  */
-class SampleFormat : public PixSampleFmtWrapper<SampleFormat, AVSampleFormat>
+class AVCPP_EXPORT SampleFormat : public PixSampleFmtWrapper<SampleFormat, AVSampleFormat>
 {
 public:
     enum Alignment

--- a/src/avcpp/stream.h
+++ b/src/avcpp/stream.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <memory>
 
 #include "averror.h"
@@ -12,7 +14,7 @@
 
 namespace av
 {
-class Stream : public FFWrapperPtr<AVStream>
+class AVCPP_EXPORT Stream : public FFWrapperPtr<AVStream>
 {
 private:
     friend class FormatContext;

--- a/src/avcpp/timestamp.h
+++ b/src/avcpp/timestamp.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <chrono>
 
 #include "avutils.h"
@@ -14,7 +16,7 @@ namespace av {
  * is a multiplicator. Be careful with construct Timestamp from the std::chrono::duration with floating point @a rep
  *
  */
-class Timestamp
+class AVCPP_EXPORT Timestamp
 {
 public:
     Timestamp() noexcept;
@@ -194,10 +196,10 @@ bool operator<=(const Timestamp& left, const Timestamp& right) noexcept
 // Math operations
 //
 
-Timestamp operator+(const Timestamp& left, const Timestamp &right) noexcept;
-Timestamp operator-(const Timestamp& left, const Timestamp &right) noexcept;
-Timestamp operator*(const Timestamp& left, const Timestamp &right) noexcept;
-Timestamp operator/(const Timestamp& left, const Timestamp &right) noexcept;
+AVCPP_EXPORT Timestamp operator+(const Timestamp& left, const Timestamp &right) noexcept;
+AVCPP_EXPORT Timestamp operator-(const Timestamp& left, const Timestamp &right) noexcept;
+AVCPP_EXPORT Timestamp operator*(const Timestamp& left, const Timestamp &right) noexcept;
+AVCPP_EXPORT Timestamp operator/(const Timestamp& left, const Timestamp &right) noexcept;
 
 //
 // Output

--- a/src/avcpp/videorescaler.h
+++ b/src/avcpp/videorescaler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "avcpp/avcpp_export.h"
+
 #include <iostream>
 #include <memory>
 
@@ -34,7 +36,7 @@ enum SwsFlags
     SwsFlagErrorDiffusion = SWS_ERROR_DIFFUSION,
 };
 
-class VideoRescaler : public FFWrapperPtr<SwsContext>, public noncopyable
+class AVCPP_EXPORT VideoRescaler : public FFWrapperPtr<SwsContext>, public noncopyable
 {
 public:
     VideoRescaler();


### PR DESCRIPTION
The PR I made before for adding Windows shared library support with WINDOWS_EXPORT_ALL_SYMBOLS  in #149 is not not really a best practice and meant as more of a temporary measure before actually exporting symbols. This PR will actually explicitly specify symbol exports in a cross platform manner using CMake's tools, and set symbol visibility to default to hidden for shared builds.