### PR TITLE
Fix CMake 4.0+ whitespace error

### DIFF
--- a/cmake/FindFFmpeg.cmake
+++ b/cmake/FindFFmpeg.cmake
@@ -246,7 +246,7 @@ if (TRUE)
         set_target_properties(FFmpeg::${_lowerComponent} PROPERTIES
             INTERFACE_COMPILE_OPTIONS "${${_component}_DEFINITIONS}"
             INTERFACE_INCLUDE_DIRECTORIES ${${_component}_INCLUDE_DIRS}
-            INTERFACE_LINK_LIBRARIES "${${_component}_LIBRARY} ${${_component}_LIBRARIES} ${PC_${_component}_LIBRARIES}"
+            INTERFACE_LINK_LIBRARIES "${${_component}_LIBRARY}" "${${_component}_LIBRARIES}" "${PC_${_component}_LIBRARIES}"
             IMPORTED_LINK_INTERFACE_MULTIPLICITY 3)
       endif()
     else()


### PR DESCRIPTION
Compiling on my system without this would fail like so:
```
-- Generating done (0.1s)
CMake Error at cmake/FindFFmpeg.cmake:245 (add_library):
  Target "FFmpeg::avcodec" links to item " /usr/lib/libavcodec.so avcodec"
  which has leading or trailing whitespace.  This is now an error according
  to policy CMP0004.
Call Stack (most recent call first):
  CMakeLists.txt:54 (find_package)
```

Behaviour changed in CMake 4.0 https://cmake.org/cmake/help/latest/policy/CMP0004.html

